### PR TITLE
IuguMethod update must be PUT

### DIFF
--- a/lib/IuguMethod.basic.js
+++ b/lib/IuguMethod.basic.js
@@ -20,7 +20,7 @@ module.exports = {
   }),
 
   update: iuguMethod({
-    method: 'POST',
+    method: 'PUT',
     path: '{id}',
     urlParams: ['id']
   }),


### PR DESCRIPTION
Olá, fazendo alguns testes com essa lib, me deparei nesse possível bug.
Como default, a lib trata os updates como method 'POST', porém na API de vocês, updates requerem 'PUT'. 
Então os updates não estavam funcionando. Nos meus testes essa alteração corrigiu o problema. 
